### PR TITLE
AUTHORS and manpage fixes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,5 +6,5 @@ Copyright:
     Copyright (c) 2010-2012 Razor team
     Copyright (c) 2012-2014 LXQt team
 
-License: GPL-2 and LGPL-2.1+
+License: LGPL-2.1+
 The full text of the licenses can be found in the 'COPYING' file.

--- a/man/lxqt-policykit-agent.1
+++ b/man/lxqt-policykit-agent.1
@@ -34,7 +34,7 @@ that ask for the user's key need for action.
 The module only are showed on \fBLXQt\fR desktop, but u can create an autostart action 
 for u prefered desktop environment.
 .SH "REPORTING BUGS"
-Report bugs to https://github.com/LXDE/LXQt/issues
+Report bugs to https://github.com/lxde/lxqt/issues
 .SH "SEE ALSO"
 \fBLXQt\fR it has been tailored for users who value simplicity, speed, and
 an intuitive interface, also intended for less powerful machines. See:
@@ -49,4 +49,4 @@ an intuitive interface, also intended for less powerful machines. See:
 .P
 .SH AUTHOR
 This manual page was created by \fBPICCORO Lenz McKAY\fR \fI<mckaygerhard@gmail.com>\fR
-for \fBLXQt\fR project and VENENUX GNU/Linux but can be used by others.
+for \fBLXQt\fR project and VENENUX GNU/Linux.


### PR DESCRIPTION
GPL2 not used - removed in AUTHORS
Fixed link to Github LXQt issues
Fix wording in manpage - 'can be used by others' make no sense for a file under
LGPL root license
fixes lxde/lxqt/issues/802