### PR TITLE
agent: Handle multiple identities correctly

### DIFF
--- a/src/policykitagent.cpp
+++ b/src/policykitagent.cpp
@@ -118,7 +118,7 @@ void PolicykitAgent::request(const QString &request, bool echo)
     m_gui->setPrompt(identity, request, echo);
     connect(m_gui, &QDialog::finished, [this, session] (int result)
     {
-        if (result == QDialog::Accepted && m_gui->identity().toString() == m_SessionIdentity[session].toString())
+        if (result == QDialog::Accepted && m_gui->identity() == m_SessionIdentity[session].toString())
             session->setResponse(m_gui->response());
         else
             session->cancel();
@@ -132,7 +132,7 @@ void PolicykitAgent::completed(bool gainedAuthorization)
     Q_ASSERT(session);
     Q_ASSERT(m_gui);
 
-    if (m_gui->identity().toString() == m_SessionIdentity[session].toString())
+    if (m_gui->identity() == m_SessionIdentity[session].toString())
     {
         if (!gainedAuthorization)
         {

--- a/src/policykitagentgui.cpp
+++ b/src/policykitagentgui.cpp
@@ -47,10 +47,18 @@ PolicykitAgentGUI::PolicykitAgentGUI(const QString &actionId,
     messageLabel->setText(message);
     iconLabel->setPixmap(XdgIcon::fromTheme(iconName).pixmap(64, 64));
 
+    const uid_t current_uid = getuid();
+    int current_user_index = -1;
     foreach (PolkitQt1::Identity identity, identities)
     {
+        const int i = identityComboBox->count(); // index of the added item
         identityComboBox->addItem(identity.toString());
+        PolkitQt1::UnixUserIdentity const * const u_id = static_cast<PolkitQt1::UnixUserIdentity *>(&identity);
+        if (u_id != nullptr && u_id->uid() == current_uid)
+            current_user_index = i;
     }
+    if (current_user_index != -1)
+        identityComboBox->setCurrentIndex(current_user_index);
     connect(identityComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &PolicykitAgentGUI::onIdentityChanged);
     passwordEdit->setFocus(Qt::OtherFocusReason);
 }

--- a/src/policykitagentgui.cpp
+++ b/src/policykitagentgui.cpp
@@ -27,6 +27,7 @@
 
 #include <XdgIcon>
 #include "policykitagentgui.h"
+#include <unistd.h>
 
 namespace LXQtPolicykit
 {
@@ -48,31 +49,47 @@ PolicykitAgentGUI::PolicykitAgentGUI(const QString &actionId,
 
     foreach (PolkitQt1::Identity identity, identities)
     {
-        m_identityMap[identity.toString()] = identity;
         identityComboBox->addItem(identity.toString());
     }
+    connect(identityComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &PolicykitAgentGUI::onIdentityChanged);
+    passwordEdit->setFocus(Qt::OtherFocusReason);
 }
 
 void PolicykitAgentGUI::setPrompt(const PolkitQt1::Identity &identity, const QString &text, bool echo)
 {
-    int ix = identityComboBox->findText(identity.toString());
+    const int ix = identityComboBox->findText(identity.toString());
     if (ix != -1)
     {
-        identityComboBox->setCurrentIndex(ix);
-        passwordEdit->setFocus(Qt::OtherFocusReason);
+        identityComboBox->setItemData(ix, text, RolePromptText);
+        identityComboBox->setItemData(ix, echo, RolePromptEcho);
+
+        if (ix == identityComboBox->currentIndex())
+        {
+            promptLabel->setText(text);
+            passwordEdit->setEchoMode(echo ? QLineEdit::Normal : QLineEdit::Password);
+        }
     }
-    promptLabel->setText(text);
-    passwordEdit->setEchoMode(echo ? QLineEdit::Normal : QLineEdit::Password);
 }
 
-PolkitQt1::Identity PolicykitAgentGUI::identity()
+QString PolicykitAgentGUI::identity()
 {
-    return m_identityMap[identityComboBox->currentText()];
+    Q_ASSERT(identityComboBox->currentIndex() != -1);
+    return identityComboBox->currentText();
 }
 
 QString PolicykitAgentGUI::response()
 {
     return passwordEdit->text();
+}
+
+void PolicykitAgentGUI::onIdentityChanged(int index)
+{
+    QVariant text = identityComboBox->itemData(index, RolePromptText);
+    QVariant echo = identityComboBox->itemData(index, RolePromptEcho);
+    if (text != QVariant{})
+        promptLabel->setText(text.toString());
+    if (echo != QVariant{})
+        passwordEdit->setEchoMode(echo.toBool() ? QLineEdit::Normal : QLineEdit::Password);
 }
 
 } // namespace

--- a/src/policykitagentgui.cpp
+++ b/src/policykitagentgui.cpp
@@ -25,7 +25,7 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#include <XdgIcon>
+#include <QIcon>
 #include "policykitagentgui.h"
 #include <unistd.h>
 
@@ -45,7 +45,10 @@ PolicykitAgentGUI::PolicykitAgentGUI(const QString &actionId,
     Q_UNUSED(details); // it seems too confusing for end user (=me)
 
     messageLabel->setText(message);
-    iconLabel->setPixmap(XdgIcon::fromTheme(iconName).pixmap(64, 64));
+    QIcon icon = QIcon::fromTheme(iconName);
+    if (icon.isNull())
+        icon = QIcon::fromTheme(QLatin1String("dialog-question"));
+    iconLabel->setPixmap(icon.pixmap(64, 64));
 
     const uid_t current_uid = getuid();
     int current_user_index = -1;

--- a/src/policykitagentgui.h
+++ b/src/policykitagentgui.h
@@ -40,6 +40,13 @@ class PolicykitAgentGUI : public QDialog, public Ui::PolicykitAgentGUI
 {
     Q_OBJECT
 
+private:
+    enum DataRoles
+    {
+        RolePromptText = Qt::UserRole
+            , RolePromptEcho
+    };
+
 public:
     PolicykitAgentGUI(const QString &actionId,
                       const QString &message,
@@ -48,11 +55,14 @@ public:
                       const PolkitQt1::Identity::List &identities);
 
     void setPrompt(const PolkitQt1::Identity &identity, const QString &text, bool echo);
-    PolkitQt1::Identity identity();
+    /*! \brief Returns currently selected identity (serialized by toString())
+     */
+    QString identity();
     QString response();
 
-private:
-    QHash<QString,PolkitQt1::Identity> m_identityMap;
+public slots:
+    void onIdentityChanged(int index);
+
 };
 
 } // namespace


### PR DESCRIPTION
Set the response on maximum one polkit session and correctly handle the
signalling.

closes lxde/lxqt#1126

Please, review the change carefuly as I saw the code for the first time and don't know much about the polkit agents etc...