### PR TITLE
Drops Qt5Core_VERSION_STRING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(POLKIT_AGENT_BINARY_DIR "${CMAKE_INSTALL_BINDIR}" CACHE FILEPATH "Directory 
 find_package(PolkitQt5-1 REQUIRED)
 find_package(Qt5LinguistTools REQUIRED QUIET)
 find_package(Qt5Widgets REQUIRED)
-message(STATUS "Building with Qt${Qt5Core_VERSION_STRING}")
+message(STATUS "Building with Qt${Qt5Core_VERSION}")
 
 find_package(lxqt REQUIRED)
 


### PR DESCRIPTION
Use Qt5Core_VERSION. Qt5Core_VERSION_STRING is a compatibility variable and
it was removed in Qt 5.9 release.